### PR TITLE
Udpate get note comments

### DIFF
--- a/xhs/core.py
+++ b/xhs/core.py
@@ -505,7 +505,7 @@ class XhsClient:
         :rtype: dict
         """
         uri = "/api/sns/web/v2/comment/page"
-        params = {"note_id": note_id, "cursor": cursor}
+        params = {"note_id": note_id, "cursor": cursor, "image_formats": "jpg,webp,avif"}
         return self.get(uri, params)
 
     def get_note_sub_comments(
@@ -739,14 +739,14 @@ class XhsClient:
         }
         return self.get(uri, headers=headers, is_creator=True)
 
-    def get_creator_note_list(self, tab:int = 0, page:int = 0):
+    def get_creator_note_list(self, tab: int = 0, page: int = 0):
         uri = "/api/galaxy/creator/note/user/posted"
         params = {"tab": tab, "page": page}
         headers = {
             "Referer": "https://creator.xiaohongshu.com/new/note-manager"
         }
         return self.get(uri, params, headers=headers, is_creator=True)
-      
+
     def get_notes_statistics(self, page: int = 1, page_size: int = 48, sort_by="time", note_type=0, time=30,
                              is_recent=True):
         """


### PR DESCRIPTION
Added an extra param to get the images. Otherwise there is no images returned.
Example now:
```
{'at_users': [], 
'sub_comment_cursor': '6675a72300000000050055e4', 
'id': '6675a6f8000000000d00d121', 
'liked': False, 
'user_info': {'user_id': '621c5858000000001000ff14', 'nickname': '少来我这里找骂', 'image': 'https://sns-avatar-qc.xhscdn.com/avatar/63a6a741f6c0abc638454436.jpg?imageView2/2/w/120/format/jpg'}, 
'sub_comment_count': '2', 
'sub_comment_has_more': True, 
'status': 0, 'content': '只能说符合刻板印象。。。', 
'show_tags': [], 'create_time': 1718986490000, 
'sub_comments': [{...}], 
'note_id': '6674582b000000001f00700b', 
'like_count': '0', 
'ip_location': '内蒙古', 
'pictures': [{...}]}
```
<img width="552" alt="Screenshot 2024-06-22 at 00 40 58" src="https://github.com/ReaJason/xhs/assets/6411481/45c4d006-5fcf-448e-9616-b2d4b5d282d9">
