### PR TITLE
feat(upload): 支持视频笔记大文件分片上传并添加进度显示

### DIFF
--- a/xhs/core.py
+++ b/xhs/core.py
@@ -834,12 +834,21 @@ class XhsClient:
         upload_id = self.get_upload_id(file_id, token)
         parts = []
         part_num = 1
+        
+        # 获取文件总大小
+        total_size = os.path.getsize(file_path)
+        uploaded_size = 0
+        chunk_size = 1024 * 1024 * 5  # 5MB per chunk
+        
+        print(f"\n开始上传文件: {os.path.basename(file_path)}")
+        print(f"文件大小: {total_size / 1024 / 1024:.2f}MB")
+        
         with open(file_path, "rb") as f:
-            # read with 5M each time to upload
             while True:
-                data = f.read(1024 * 1024 * 5)
+                data = f.read(chunk_size)
                 if not data:
                     break
+                    
                 params = {
                     "partNumber": part_num,
                     "uploadId": upload_id
@@ -849,7 +858,14 @@ class XhsClient:
                     "PartNumber": part_num,
                     "ETag": res.headers["Etag"]
                 })
+                
+                uploaded_size += len(data)
+                progress = (uploaded_size / total_size) * 100
+                print(f"\r上传进度: {progress:.1f}% ({uploaded_size}/{total_size} bytes)", end="", flush=True)
+                
                 part_num += 1
+                
+        print("\n分片上传完成，正在合并文件...")
         return self.create_complete_multipart_upload(file_id, token, upload_id, parts)
 
     def upload_file(
@@ -871,8 +887,8 @@ class XhsClient:
         max_file_size = 5 * 1024 * 1024
         url = "https://ros-upload.xiaohongshu.com/" + file_id
         if os.path.getsize(file_path) > max_file_size and content_type == "video/mp4":
-            raise Exception("video too large, < 5M")
-            # return self.upload_file_with_slice(file_id, token, file_path)
+            # 启用分片上传，支持大文件
+            return self.upload_file_with_slice(file_id, token, file_path)
         else:
             headers = {"X-Cos-Security-Token": token, "Content-Type": content_type}
             with open(file_path, "rb") as f:


### PR DESCRIPTION
- 移除5MB视频文件大小限制
- 启用分片上传功能支持大文件
- 添加文件上传进度实时显示
  - 显示文件名和总大小
  - 显示上传百分比和字节数
  - 添加上传状态提示
  
![QQ20250325-234515](https://github.com/user-attachments/assets/4d9321c5-05ed-4766-90ac-7947a3be9fbe)
